### PR TITLE
Matcher to verify allow value for attribute

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
+--format progress
 --color

--- a/README.md
+++ b/README.md
@@ -20,7 +20,21 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Entity
+
+```ruby
+class Person
+  include Lotus::Validations
+
+  attribute :email, format: /@/
+end
+```
+
+### Spec
+```ruby
+it { is_expected.to allow_value("leo@nospam.org").for(:email) }
+it { is_expected.to_not allow_value('leo-at-nospam.org').for(:email) }
+```
 
 ## Development
 

--- a/lib/shoulda/lotus.rb
+++ b/lib/shoulda/lotus.rb
@@ -1,4 +1,5 @@
 require 'shoulda/lotus/version'
+require 'shoulda/lotus/matchers'
 
 module Shoulda
   module Lotus

--- a/lib/shoulda/lotus/matchers.rb
+++ b/lib/shoulda/lotus/matchers.rb
@@ -1,0 +1,8 @@
+require 'shoulda/lotus/matchers/allow_value_matcher'
+
+module Shoulda
+  module Lotus
+    module Matchers
+    end
+  end
+end

--- a/lib/shoulda/lotus/matchers/allow_value_matcher.rb
+++ b/lib/shoulda/lotus/matchers/allow_value_matcher.rb
@@ -1,0 +1,40 @@
+module Shoulda
+  module Lotus
+    module Matchers
+      def allow_value(value)
+        AllowValueMatcher.new(value)
+      end
+
+      class AllowValueMatcher
+        def initialize(value)
+          @value = value
+        end
+
+        def matches?(target)
+          @target = target
+          @target.send("#{@attribute}=", @value)
+          @target.valid?
+
+          !(@target.errors.for(@attribute).select { |error| error.attribute == @attribute.to_s && error.validation == :format }.size > 0)
+        end
+
+        def description
+          "allow '#{@value}' to be set to '#{@attribute}'"
+        end
+
+        def failure_message
+          "'#{@value}' is an invalid format for '#{@attribute}'"
+        end
+
+        def failure_message_when_negated
+          "'#{@value}' is a valid format for '#{@attribute}'"
+        end
+
+        def for(attribute)
+          @attribute = attribute
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/shoulda/lotus/matchers/validate_presence_matcher.rb
+++ b/lib/shoulda/lotus/matchers/validate_presence_matcher.rb
@@ -1,0 +1,6 @@
+module Shoulda
+  module Lotus
+    module Matchers
+    end
+  end
+end

--- a/shoulda-lotus.gemspec
+++ b/shoulda-lotus.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+
+  spec.add_dependency 'lotus-validations', '~> 0.3.2'
 end

--- a/spec/fixtures/person.rb
+++ b/spec/fixtures/person.rb
@@ -1,0 +1,7 @@
+require 'lotus/validations'
+
+class Person
+  include Lotus::Validations
+
+  attribute :email, format: /@/
+end

--- a/spec/shoulda/matchers/allow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/allow_value_matcher_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe Shoulda::Lotus::Matchers::AllowValueMatcher do
+  include Shoulda::Lotus::Matchers
+
+  it '#description' do
+    matcher = allow_value('beer').for(:bar)
+
+    expect(matcher.description).to eq "allow 'beer' to be set to 'bar'"
+  end
+
+  context 'an attribute with a validation' do
+    let(:model) { Person.new }
+
+    it 'accept a valid value' do
+      expect(model).to allow_value('leo@nospam.org').for(:email)
+    end
+
+    it 'reject an invalid value' do
+      expect(model).to_not allow_value('leo-at-nospam.org').for(:email)
+    end
+  end
+end

--- a/spec/shoulda/matchers/validate_presence_matcher_spec.rb
+++ b/spec/shoulda/matchers/validate_presence_matcher_spec.rb
@@ -1,6 +1,0 @@
-require 'spec_helper'
-
-# RSpec.describe Shoulda::Lotus::Matchers::ValidatePresenceMatcher do
-#   it '#validate_presence_of'
-#   it 'class'
-# end

--- a/spec/shoulda/matchers/validate_presence_matcher_spec.rb
+++ b/spec/shoulda/matchers/validate_presence_matcher_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+# RSpec.describe Shoulda::Lotus::Matchers::ValidatePresenceMatcher do
+#   it '#validate_presence_of'
+#   it 'class'
+# end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'shoulda/lotus'
+require 'fixtures/person'


### PR DESCRIPTION
# Usage:
## Class

``` ruby
class Person
  include Lotus::Validations

  attribute :email, format: /@/
end
```
## Spec

``` ruby
it { is_expected.to allow_value("leo@nospam.org").for(:email) }
it { is_expected.to_not allow_value('leo-at-nospam.org').for(:email) }
```
